### PR TITLE
feat: shorten sweetalert popMsg time

### DIFF
--- a/src/utils/swal.js
+++ b/src/utils/swal.js
@@ -5,7 +5,7 @@ export const Toast = Swal.mixin({
   width: '25rem',
   position: 'top',
   showConfirmButton: false,
-  timer: 3000,
+  timer: 1000,
   timerProgressBar: true
 })
 


### PR DESCRIPTION
目前提示時間為 3 秒，由於提示位置為正上方，容易蓋住上方導覽列，造成使用體驗不佳，因此縮短提示時間至 1 秒。