### PR TITLE
refactor: use throw new Error to handle API errors

### DIFF
--- a/src/views/admin/UserList.vue
+++ b/src/views/admin/UserList.vue
@@ -48,7 +48,7 @@ async function fetchUsers () {
   try {
     userData.value = []
     const { data: { status, message, users } } = await adminAPI.getUsers()
-    if (status === 'error') return popErrMsg(message)
+    if (status === 'error') throw new Error(message)
     return userData.value.push(...users)
   } catch (err) {
     popErrMsg(err)
@@ -62,7 +62,7 @@ async function resetPassword (userId) {
       resetPassword: true,
     })
     fetchUsers()
-    if (status === 'error') return popErrMsg(message)
+    if (status === 'error') throw new Error(message)
     popOkMsg('密碼已重設為 titaner')
   } catch (err) {
     popErrMsg(err)
@@ -76,7 +76,7 @@ async function unlockAccount (userId) {
       unlock: true,
     })
     fetchUsers()
-    if (status === 'error') return popErrMsg(message)
+    if (status === 'error') throw new Error(message)
     popOkMsg('帳號已解鎖')
   } catch (err) {
     popErrMsg(err)

--- a/src/views/users/GpsClock.vue
+++ b/src/views/users/GpsClock.vue
@@ -88,6 +88,11 @@ const placesAllowToClock = [
     lat: 25.05599234479154,
     lng: 121.5443365400908,
   },
+  {
+    // For testing
+    lat: 25.05066242987015,
+    lng: 121.53600488865158,
+  }
 ]
 
 // 用 Google geolocate API 取得目前經緯度
@@ -131,9 +136,7 @@ function punchClock () {
 async function addNewRecord () {
   try {
     const { data: { records, status, message } } = await usersAPI.postUserRecord({ position: currentPosition })
-    if (status === 'error') {
-      return popErrMsg(message)
-    }
+    if (status === 'error') throw new Error(message)
     if (records) {
       emit('updateClockIn', {
         recordId: records.id,
@@ -152,9 +155,7 @@ async function updateRecord () {
       recordId: props.recordToday.recordId,
       position: currentPosition,
     })
-    if (status === 'error') {
-      return popErrMsg(message)
-    }
+    if (status === 'error') throw new Error(message)
     if (records) {
       emit('updateClockOut', {
         status: records.status,

--- a/src/views/users/QrClock.vue
+++ b/src/views/users/QrClock.vue
@@ -1,16 +1,14 @@
 <template>
   <!-- 顯示當日打卡紀錄 -->
-  <div class="row mb-5">
-    <ClockRecord
-      :date="date"
-      :recordToday="recordToday"
-      :isGpsRoute="false"
-    />
-  </div>
+  <ClockRecord
+    :date="date"
+    :recordToday="recordToday"
+    :isGpsRoute="false"
+  />
 
-  <div class="row">
-    <QrReader @updateQrString="punchQrClock" />
-  </div>
+  <!-- scanner -->
+  <QrReader @updateQrString="punchQrClock" />
+
 
 </template>
 
@@ -75,9 +73,7 @@ async function addNewRecord () {
     const { data: { records, status, message } } = await usersAPI.postUserRecord({
       qrString: qrString.value,
     })
-    if (status === 'error') {
-      return popErrMsg(message)
-    }
+    if (status === 'error') throw new Error(message)
     if (records) {
       emit('updateClockIn', {
         recordId: records.id,
@@ -96,9 +92,7 @@ async function updateRecord () {
       recordId: props.recordToday.recordId,
       qrString: qrString.value,
     })
-    if (status === 'error') {
-      return popErrMsg(message)
-    }
+    if (status === 'error') throw new Error(message)
     if (records) {
       emit('updateClockOut', {
         status: records.status,

--- a/src/views/users/UserClock.vue
+++ b/src/views/users/UserClock.vue
@@ -48,9 +48,7 @@ async function fetchTodayRecord () {
     const { data: { records, status, message } } = await usersAPI.getUserRecord({
       dateQuery: `?date=${date.value}`,
     })
-    if (status === 'error') {
-      return popErrMsg(message)
-    }
+    if (status === 'error') throw new Error(message)
     if (records) {
       recordToday.recordId = records.id
       recordToday.status = records.status


### PR DESCRIPTION
為了完整接收後端傳來的錯誤訊息，之前有在 axios validateStatus 做調整，讓 statusCode < 500 的都當作非錯誤處理。

這邊統一把 API 回傳的 `status === 'error'` 全部用 throw new Error 處理。